### PR TITLE
feat(docker): dockerize DynIPSync app

### DIFF
--- a/dyn_ip_sync/docker-compose.yml
+++ b/dyn_ip_sync/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.9"
+
+services:
+  server_a:
+    build:
+      context: .
+      dockerfile: server_a/Dockerfile
+    container_name: dynipsync_server_a
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./data:/data   # persist last IP
+    restart: unless-stopped
+
+  server_b:
+    build:
+      context: .
+      dockerfile: server_b/Dockerfile
+    container_name: dynipsync_server_b
+    volumes:
+      - ./data:/data   # persist last IP
+    restart: unless-stopped

--- a/dyn_ip_sync/server_a/Dockerfile
+++ b/dyn_ip_sync/server_a/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source code
+COPY .env .
+COPY shared ./shared
+COPY server_a ./server_a
+
+# Expose port
+EXPOSE 5000
+
+# Run Flask server
+CMD ["python", "-m", "server_a.server"]

--- a/dyn_ip_sync/server_b/Dockerfile
+++ b/dyn_ip_sync/server_b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source code
+COPY .env .
+COPY shared ./shared
+COPY server_b ./server_b
+
+# Run client
+CMD ["python", "-m", "server_b.client"]


### PR DESCRIPTION
- add Dockerfile for server_a (Flask API)
- add Dockerfile for server_b (IP client)
- add docker-compose.yml to orchestrate both services
- mount ./data volume to persist last known IP
- configure containers with restart policies for reliability